### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,18 +9,18 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   with_options presence: true do
-	validates :name
-	validates :information
-	validates :image
-	validates :price,  format: { with: /\A[0-9]+\z/, message: "は半角数字で入力してください"}
+    validates :name
+    validates :information
+    validates :image
+    validates :price, format: { with: /\A[0-9]+\z/, message: 'は半角数字で入力してください' }
   end
 
-  with_options numericality: {other_than: 1} do
+  with_options numericality: { other_than: 1 } do
     validates :state_id
     validates :category_id
-    validates :shipping_burden_id 
+    validates :shipping_burden_id
     validates :shipper_prefecture_id
-	validates :shipping_days_id
+    validates :shipping_days_id
   end
   validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,56 +125,55 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+      <% if @items != nil %>
+        <% @items.each do | item | %>
+          <li class='list'>
+            <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
             </div>
-          </div>
-        </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= ShippingBurden.data[item.shipping_burden_id-1][:name] %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+      <% else %>
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -144,7 +144,7 @@
                 <%= item.name %>
               </h3>
               <div class='item-price'>
-                <span><%= item.price %>円<br><%= ShippingBurden.data[item.shipping_burden_id-1][:name] %></span>
+                <span><%= item.price %>円<br><%= item.shipping_burden.name %></span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,11 @@
               <%= image_tag item.image, class: "item-img" %>
 
               <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
+              <%#<div class='sold-out'>
                 <span>Sold Out!!</span>
               </div>
               <%# //商品が売れていればsold outを表示しましょう %>
-
+            
             </div>
             <div class='item-info'>
               <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,7 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-      <% if @items != nil %>
+      <% if @items != [] %>
         <% @items.each do | item | %>
           <li class='list'>
             <%= link_to "#" do %>
@@ -137,7 +137,7 @@
                 <span>Sold Out!!</span>
               </div>
               <%# //商品が売れていればsold outを表示しましょう %>
-            
+
             </div>
             <div class='item-info'>
               <h3 class='item-name'>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'priceが半角数字でなければ出品できないこと' do
-        @item.price = ""
+        @item.price = ''
         @item.valid?
         expect(@item.errors.full_messages).to include('Priceは半角数字で入力してください')
       end


### PR DESCRIPTION
# what
商品一覧表示機能の実装
# why
商品一覧表示のため
# URL
https://gyazo.com/c0410be9efdef14163aa22df78367663
一覧表示機能の動作確認です。
https://gyazo.com/0ea808b47b94d0249985f641ad8906d7
ログアウト時でも商品一覧ページにアクセスができることの確認です。
https://gyazo.com/3952e04f7485cb2e97b25ae65c0fe943
商品データがない場合、ダミー商品が表示されることの確認です。